### PR TITLE
Fix Azure Pipelines templates

### DIFF
--- a/Azure Pipelines/Azure-Pipelines-template-linux-with-indirect-build-tracing.yml
+++ b/Azure Pipelines/Azure-Pipelines-template-linux-with-indirect-build-tracing.yml
@@ -1,105 +1,130 @@
 # This sample YAML file shows how to configure an Azure Pipeline to analyze a repository using the CodeQL CLI Bundle
 # This example assumes a Linux environment and takes advantage of indirect build tracing ("sandwich mode") to leverage an existing set of build command
 
+# Use this when a repository is stored in GitHub
+# To run Codeql in azure repos see: https://learn.microsoft.com/en-us/azure/devops/repos/security/github-advanced-security-code-scanning?view=azure-devops
+
+# The pipeline needs have a variable called GITHUB_TOKEN (don't forget to set it as secret)
+# This secret will contain a personal access token. Either classic or fine grained (preferably)
+# The Clasic token requires the following scopes: Repo
+# The fine grained token requires the following permissions: Code scanning alerts (read and write)
+
+# Adapt the trigger to your needs
 trigger:
     branches:
-        include:
-        - '*'
+      include:
+      - '*'
     paths:
-        exclude:
-        - test/*
-        - doc/*
-        - lib/*
-        include:
-        - src/*
-  resources:
-      repositories:
-      - repository: templates
-          type: github
-          name: octo-org/example-repo-2
-          endpoint: octo-org
+      exclude:
+      - test/*
+      - doc/*
+      - lib/*
+      include:
+      - src/*
+
+variables:
+  # Language to scan. Possible values
+  #   cpp, csharp, go, java, javascript, python, ruby, swift
+  language: java   
 
 stages:
-- stage: __default
-    jobs:
-    - job: Job
-        workspace:
-            clean: all
-        steps:
+- stage:
+  jobs:
+    - job:
+      displayName: CodeQL analyze
+
+      pool:
+        vmImage: 'ubuntu-latest'
+      workspace:
+          clean: all
+      steps:
 
         # OPTIONAL: Download CodeQL CLI Bundle
         # The CodeQL bundle (containing the CodeQL CLI as well as the pre-compiled CodeQL Query Suites, which is recommended for CI/CD integration) can either be download as part of the pipeline,
         # or pre-downloaded and placed on the CI/CD build machine(s). In this example, we download the latest CLI bundle (at time of writing) as part of the pipeline from
         # https://github.com/github/codeql-action/releases, extract it and place it on the PATH.
-        - task: ShellScript@1
-            displayName: Download CodeQL CLI Bundle
-            inputs:
-                targetType: inline
-                script: >
-                    wget https://github.com/github/codeql-action/releases/latest/download/codeql-bundle-linux64.tar.gz -O ../codeql-bundle-linux64.tar.gz
-                    tar xzvf ../codeql-bundle-linux64.tar.gz -C ../
-                    rm ../codeql-bundle-linux64.tar.gz
-                    export PATH=$(cd ..; pwd)/codeql:$PATH
-            }
-        }
+        - script: |          
+              wget https://github.com/github/codeql-action/releases/latest/download/codeql-bundle-linux64.tar.gz \
+                -O ../codeql-bundle-linux64.tar.gz \
+                --show-progress \
+                --progress=dot:mega 
+
+              tar xzvf ../codeql-bundle-linux64.tar.gz -C ../
+              rm ../codeql-bundle-linux64.tar.gz
+
+              # Make sure CLI is on the path
+              cli_path="$(cd ..; pwd)/codeql"
+              echo "##vso[task.prependpath]$cli_path"
+
+              sarif_file=$(mktemp)
+
+              echo "##vso[task.setvariable variable=sarif_file;]$sarif_file"
+          displayName: Download CodeQL CLI Bundle
 
         # Initialize CodeQL
         # Create a skeleton structure for a CodeQL database that doesn’t have a raw QL dataset yet, but is ready for running extractor steps
         # Prior to running any build commands, the generated scripts containing environment variables must be sourced.
         # Full documentation for database init step: https://codeql.github.com/docs/codeql-cli/manual/database-init/
-        - task: ShellScript@2
-            displayName: Initialize CodeQL database
-            inputs:
-                # Assumes the source code is checked out to the current working directory.
-                # Creates a database at `<current working directory>/db`.
-                script: "codeql database init --language java --source-root . --begin-tracing db"
+        - script: |
+            # You may need to change --source-root if checking out multiple repositories
+            codeql database init db --language="$(language)" --source-root="$(Build.SourcesDirectory)" --begin-tracing 
+          displayName: Initialize CodeQL database
 
-        # Source environment variables
-        # Read the generated environment variables and values, and set them so they are available for subsequent commands in the build pipeline. This is done in PowerShell in this example.
-        - task: ShellScript@3
-           displayName: Set CodeQL environment variables
-           inputs:
-              targetType: inline
-              script: ". db/temp/tracingEnvironment/start-tracing.sh"
+        - script: |
+            # Starts tracing and exports to the rest of the pipeline any environment variable it has been
+            # defined by the start-tracing script
+            env_before=$(printenv | cut -d '=' -f 1 | sort)
+            . db/temp/tracingEnvironment/start-tracing.sh
+            env_after=$(printenv | cut -d '=' -f 1 | sort)
 
-        # Run build commands
-        # In this example, we have a simple maven project with a pom.xml in the root of the repository, and a settings file in a subdirectory
-        # For Code Scanning purposes, we only need to compile the code. As such, we disable executing our test suite. This can be changed according to your needs    
-        - task: ShellScript@4
-           displayName: Run build commands
-           inputs:
-              targetType: inline
-              script: "mvn clean install -DskipTests=true -s settings/settings.xml"
+            comm -13 <(echo "$env_before") <(echo "$env_after") | while read -r env_name; do    
+                echo "##vso[task.setvariable variable=$env_name;]${!env_name}"
+            done
+          displayName: Start CodeQL tracing
 
-        # Finalize CodeQL Database
-        # Finalize a database that was created with codeql database init and subsequently seeded with analysis data using codeql database trace-command.
-        # This needs to happen before the new database can be queried.
-        # Full documentation for database finalize step: https://codeql.github.com/docs/codeql-cli/manual/database-finalize/
-        - task: ShellScript@5
-           displayName: Finalize CodeQL database
-           inputs:
-              script: 'codeql database finalize db'
+        # Insert here your build steps.
+        # Adding a java build as an example
+        - script: |
+            mvn clean install -DskipTests=true
+          displayName: Build Java Application
 
+          # Finalize a database that was created with codeql database init and subsequently seeded with analysis data using codeql database trace-command.
+          # This needs to happen before the new database can be queried.
+          # Full documentation for database finalize step: https://codeql.github.com/docs/codeql-cli/manual/database-finalize/
+        - script: |
+             codeql database finalize db 
+          displayName: Finalize CodeQL database
+        
         # Analyze CodeQL Database
         # Analyze a CodeQL database, producing meaningful results in the context of the source code.
         # Run a query suite (or some individual queries) against a CodeQL database, producing results, styled as alerts or paths, in SARIF or another interpreted format.
         # Note that the suite argument can accept one of the pre-compiled, out-of-the-box query suites: code-scanning, security-extended, or security-and-quality
         # Full documentation for database analyze step: https://codeql.github.com/docs/codeql-cli/manual/database-analyze/
-        - task: ShellScript@6
-            displayName: Analyze CodeQL Database
-            inputs:
-                script: "codeql database analyze db java-security-and-quality.qls --format=sarif-latest --output=./temp/results-java.sarif"
+        - script: |
+            codeql database analyze \
+              --format=sarif-latest \
+              --sarif-category="$(language)" \
+              --sarif-add-baseline-file-info \
+              --output="$(sarif_file)" \
+              db $(language)-security-and-quality.qls
+          displayName: Analyze CodeQL Database
 
         # Upload results to GitHub
         # Uploads a SARIF file to GitHub code scanning.
         # For context, please see https://docs.github.com/en/rest/reference/code-scanning#upload-an-analysis-as-sarif-data
-        # A GitHub Apps token or personal access token must be set. For best security practices, it is recommended to set the --github-auth-stdin flag and pass the token to the command through standard input. Alternatively, the GITHUB\_TOKEN environment variable can be set.
+        # A GitHub Apps token or personal access token must be set. For best security practices, it is recommended to set the --github-auth-stdin flag and pass the token to the command through standard input. Alternatively, the GITHUB_TOKEN environment variable can be set.
         # This token must have the security\_events scope.
         # Documentation for creating GitHub Apps or Personal Access Tokens are available here: https://docs.github.com/en/free-pro-team@latest/github/authenticating-to-github/creating-a-personal-access-token
         # Full documentation for github upload-results step: https://codeql.github.com/docs/codeql-cli/manual/github-upload-results/
-        - task: ShellScript@7
-            displayName: Upload results to GitHub
-            inputs:
-                script: "codeql github upload-results --sarif=./temp/results-java.sarif --github-auth-stdin --github-url=https://github.com/ --repository=octo-org/example-repo-2 --ref=refs/heads/main --commit=deb275d2d5fe9a522a0b7bd8b6b6a1c939552718"
+        - script: |
+            echo ""
+            codeql github upload-results \
+              --sarif="$(sarif_file)" \
+              --github-url=https://github.com/ \
+              --repository="$(Build.Repository.Name)" \
+              --ref="$(Build.SourceBranch)" \
+              --commit="$(Build.SourceVersion)"
+          displayName: Upload results to GitHub $(Build.Repository.Name)
+          env:
+            GITHUB_TOKEN: $(GITHUB_TOKEN)
 
-        # Other tasks go here

--- a/Azure Pipelines/Azure-Pipelines-template-linux.yml
+++ b/Azure Pipelines/Azure-Pipelines-template-linux.yml
@@ -1,78 +1,107 @@
 # This sample YAML file shows how to configure an Azure Pipeline to analyze a repository using the CodeQL CLI Bundle
+# When a repository is stored in GitHub
+# To run Codeql in azure repos see: https://learn.microsoft.com/en-us/azure/devops/repos/security/github-advanced-security-code-scanning?view=azure-devops
 # This example assumes a Linux environment
 
+# The pipeline needs have a variable called GITHUB_TOKEN (don't forget to set it as secret)
+# This secret will contain a personal access token. Either classic or fine grained (preferably)
+# The Clasic token requires the following scopes: Repo
+# The fine grained token requires the following permissions: Code scanning alerts (read and write)
+
+# Adapt the trigger to your needs
 trigger:
     branches:
-        include:
-        - '*'
+      include:
+      - '*'
     paths:
-        exclude:
-        - test/*
-        - doc/*
-        - lib/*
-        include:
-        - src/*
-  resources:
-      repositories:
-      - repository: templates
-          type: github
-          name: octo-org/example-repo-2
-          endpoint: octo-org
+      exclude:
+      - test/*
+      - doc/*
+      - lib/*
+      include:
+      - src/*
+
+variables:
+  # Language to scan. Possible values
+  #   cpp, csharp, go, java, javascript, python, ruby, swift
+  language: javascript   
 
 stages:
-- stage: __default
-    jobs:
-    - job: Job
-        workspace:
-            clean: all
-        steps:
+- stage:
+  jobs:
+    - job:
+      displayName: CodeQL analyze
+
+      pool:
+        vmImage: 'ubuntu-latest'
+      workspace:
+          clean: all
+      steps:
 
         # OPTIONAL: Download CodeQL CLI Bundle
         # The CodeQL bundle (containing the CodeQL CLI as well as the pre-compiled CodeQL Query Suites, which is recommended for CI/CD integration) can either be download as part of the pipeline,
         # or pre-downloaded and placed on the CI/CD build machine(s). In this example, we download the latest CLI bundle (at time of writing) as part of the pipeline from
         # https://github.com/github/codeql-action/releases, extract it and place it on the PATH.
-        - task: ShellScript@1
-            displayName: Download CodeQL CLI Bundle
-            inputs:
-                targetType: inline
-                script: >
-                    wget https://github.com/github/codeql-action/releases/latest/download/codeql-bundle-linux64.tar.gz -O ../codeql-bundle-linux64.tar.gz
-                    tar xzvf ../codeql-bundle-linux64.tar.gz -C ../
-                    rm ../codeql-bundle-linux64.tar.gz
-                    export PATH=$(cd ..; pwd)/codeql:$PATH
-            }
-        }
+        - script: |          
+              wget https://github.com/github/codeql-action/releases/latest/download/codeql-bundle-linux64.tar.gz \
+                -O ../codeql-bundle-linux64.tar.gz \
+                --show-progress \
+                --progress=dot:mega 
+
+              tar xzvf ../codeql-bundle-linux64.tar.gz -C ../
+              rm ../codeql-bundle-linux64.tar.gz
+
+              # Make sure CLI is on the path
+              cli_path="$(cd ..; pwd)/codeql"
+              echo "##vso[task.prependpath]$cli_path"
+
+              sarif_file=$(mktemp)
+
+              echo "##vso[task.setvariable variable=sarif_file;]$sarif_file"
+          displayName: Download CodeQL CLI Bundle
 
         # Create CodeQL Database
         # Create a CodeQL database for a source tree that can be analyzed using one of the CodeQL products.
         # Note that if the --command flag is omitted for compiled languages, the AutoBuilder will be used. For complex build instructions, consider placing build commands inside a script
         # and pass that to --command, or use indirect build tracing (aka. "sandwich mode").
         # Full documentation for database create step: https://codeql.github.com/docs/codeql-cli/manual/database-create/
-        - task: ShellScript@2
-            displayName: Create CodeQL Database
-            inputs:
-                script: "codeql database create --language=javascript --github-auth-stdin --github-url=https://github.com/ --source-root /checkouts/my-repo db"
+        - script: |
+            codeql database create db \
+              --language=$(language) \
+              --github-url=https://github.com/
+
+          displayName: Create CodeQL Database
 
         # Analyze CodeQL Database
         # Analyze a CodeQL database, producing meaningful results in the context of the source code.
         # Run a query suite (or some individual queries) against a CodeQL database, producing results, styled as alerts or paths, in SARIF or another interpreted format.
         # Note that the suite argument can accept one of the pre-compiled, out-of-the-box query suites: code-scanning, security-extended, or security-and-quality
         # Full documentation for database analyze step: https://codeql.github.com/docs/codeql-cli/manual/database-analyze/
-        - task: ShellScript@3
-            displayName: Analyze CodeQL Database
-            inputs:
-                script: "codeql database analyze --format=sarif-latest --output=./temp/results-js.sarif db javascript-security-and-quality.qls"
-
+        - script: |
+            codeql database analyze \
+              --format=sarif-latest \
+              --sarif-category="$(language)" \
+              --sarif-add-baseline-file-info \
+              --output="$(sarif_file)" \
+              db $(language)-security-and-quality.qls
+          displayName: Analyze CodeQL Database
+            
         # Upload results to GitHub
         # Uploads a SARIF file to GitHub code scanning.
         # For context, please see https://docs.github.com/en/rest/reference/code-scanning#upload-an-analysis-as-sarif-data
-        # A GitHub Apps token or personal access token must be set. For best security practices, it is recommended to set the --github-auth-stdin flag and pass the token to the command through standard input. Alternatively, the GITHUB\_TOKEN environment variable can be set.
+        # A GitHub Apps token or personal access token must be set. For best security practices, it is recommended to set the --github-auth-stdin flag and pass the token to the command through standard input. Alternatively, the GITHUB_TOKEN environment variable can be set.
         # This token must have the security\_events scope.
         # Documentation for creating GitHub Apps or Personal Access Tokens are available here: https://docs.github.com/en/free-pro-team@latest/github/authenticating-to-github/creating-a-personal-access-token
         # Full documentation for github upload-results step: https://codeql.github.com/docs/codeql-cli/manual/github-upload-results/
-        - task: ShellScript@4
-            displayName: Upload results to GitHub
-            inputs:
-                script: "codeql github upload-results --sarif=./temp/results-js.sarif --github-auth-stdin --github-url=https://github.com/ --repository=octo-org/example-repo-2 --ref=refs/heads/main --commit=deb275d2d5fe9a522a0b7bd8b6b6a1c939552718"
+        - script: |
+            echo ""
+            codeql github upload-results \
+              --sarif="$(sarif_file)" \
+              --github-url=https://github.com/ \
+              --repository="$(Build.Repository.Name)" \
+              --ref="$(Build.SourceBranch)" \
+              --commit="$(Build.SourceVersion)"
+          displayName: Upload results to GitHub $(Build.Repository.Name)
+          env:
+            GITHUB_TOKEN: $(GITHUB_TOKEN)
 
-        # Other tasks go here


### PR DESCRIPTION
Changes to Azure Pipelines Linux templates:

Fixes:
- Path was not correctly set
- Add support for a variable to hold GitHub token
- source-root (
  - Removed on non indirect bukd
  - non absolute path in indirect build
- Removed reading tokens from stdin
- Use authentication to submit Sarif files

Improvements:
- Used script alias
- Use variables for things like branch, commit,etc
- Clean up pipeline
- Add some document links
- Use a variable for github authentication
- Don't use absolute paths
- Allow specifying the language on a variable