### PR TITLE
Add CodeQL build mode to Jenkins multibranch example

### DIFF
--- a/Jenkins/Jenkinsfile-template-linux-multibranch
+++ b/Jenkins/Jenkinsfile-template-linux-multibranch
@@ -26,6 +26,8 @@ pipeline {
     // The name of the GitHub repository to run the analysis on
     GITHUB_REPO = 'od-ctcampbell/demo-jenkins-1'
     CODEQL_LANGUAGE = 'java'
+    // See https://docs.github.com/en/code-security/codeql-cli/codeql-cli-manual/database-create#--build-modemode for build mode options
+    CODEQL_BUILD_MODE = 'manual'
     CODEQL_BUILD_COMMAND = './mvnw clean package -B'
     CODEQL_QUERY_SUITE = "codeql/${CODEQL_LANGUAGE}-queries:codeql-suites/${CODEQL_LANGUAGE}-security-extended.qls"
     // The Dependency Submission Action executable archive
@@ -56,7 +58,8 @@ pipeline {
             sh '/codeql/codeql database create ./codeql-db \
                 --language ${CODEQL_LANGUAGE} \
                 --overwrite \
-                --command "${CODEQL_BUILD_COMMAND}"'
+                "${CODEQL_BUILD_MODE:+--build-mode} ${CODEQL_BUILD_MODE}" \
+                "${CODEQL_BUILD_COMMAND:+--command} ${CODEQL_BUILD_COMMAND}"'
             sh '/codeql/codeql database analyze ./codeql-db \
                 --format=sarif-latest \
                 --output=codeql-results.sarif \


### PR DESCRIPTION
This pull request primarily updates the `Jenkinsfile-template-linux-multibranch` file in the `Jenkins` directory. The changes include updating the Jenkins credentials ID, modifying the type of ref that will be checked out for a job initiated by a GitHub PR, adding a new environment variable for CodeQL build mode, and updating the URL and executable for the Dependency Submission Action. Additionally, the creation and analysis of the CodeQL database have been updated to include the new build mode and the dependency snapshot submission stage has been commented out due to errors.

Tested on local Jenkins and confirmed as working.