### PR TITLE
Fix typo in CircleCI README and update links in main README

### DIFF
--- a/CircleCI/README.md
+++ b/CircleCI/README.md
@@ -9,7 +9,7 @@ Here is a few tips and tricks for CircleCI along with some things to be aware of
 In CircleCI you might hit an error reported by CircleCI named "Error 137".
 This is because if the CI job uses over its allocated memory of the machine, CircleCI will kill the process automatically.
 
-To prevent this, restrict the CodeQL process RAM usage by addding the `--ram` argument:
+To prevent this, restrict the CodeQL process RAM usage by adding the `--ram` argument:
 
 ```bash
 codeql database analyze \

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ There are examples/guidance for:
 2. Copy the relevant pipeline file from this repository into your repository
 3. [Update the pipeline file with your required settings](https://docs.github.com/en/enterprise-cloud@latest/code-security/code-scanning/using-codeql-code-scanning-with-your-existing-ci-system/configuring-codeql-cli-in-your-ci-system)
     * read the [creating CodeQL database documentation for help](https://codeql.github.com/docs/codeql-cli/manual/database-create/)
-    * the [full CodeQL CLI documenation](https://docs.github.com/en/enterprise-cloud@latest/code-security/codeql-cli/using-the-codeql-cli/about-the-codeql-cli) may also be useful
+    * the [full CodeQL CLI documentation](https://docs.github.com/en/enterprise-cloud@latest/code-security/codeql-cli/using-the-codeql-cli/about-the-codeql-cli) may also be useful
 
 ## License
 


### PR DESCRIPTION
Hi 👋 . It's a very minor one, but this pull request includes minor corrections to documentation files to fix typographical errors.

Documentation updates:

* [`CircleCI/README.md`](diffhunk://#diff-a641dff3067da8e65cb70f8c853078667debdaac97f635aa9689b3acd698288eL12-R12): Corrected a typo in the word "adding" in the section explaining how to prevent the "Error 137" by restricting CodeQL process RAM usage.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L44-R44): Fixed a typo in the word "documentation" in the guidance section for using CodeQL CLI.